### PR TITLE
Spelling Error Fix

### DIFF
--- a/lib/jitsu.js
+++ b/lib/jitsu.js
@@ -27,7 +27,7 @@ var successCodes = jitsu.successCodes = {
   201: "Created"
 };
 
-jitsu.version       = [0, 3, 4];
+jitsu.version       = [0, 3, 5];
 jitsu.utils         = require('jitsu/utils');
 jitsu.package       = require('jitsu/package');
 jitsu.log           = require('jitsu/log');
@@ -154,7 +154,7 @@ jitsu.auth = function (callback) {
   winston.silly('Attempting to authenticate as ' + jitsu.config.username.magenta);
   jitsu.users.auth(function (err, success) {
     if (err || !success) {
-      winston.error('Unable to Autenticate as ' + jitsu.config.username.magenta);
+      winston.error('Unable to Authenticate as ' + jitsu.config.username.magenta);
       winston.error(err.message);
       return callback(err);
     } 


### PR DESCRIPTION
When responding to an incorrect password, Jitsu says "unable to autenticate" instead of "unable to authenticate."  This fixes the problem.  
