### PR TITLE
Fix for request timeout in jitsu.utils.checkVersion

### DIFF
--- a/lib/jitsu/utils/index.js
+++ b/lib/jitsu/utils/index.js
@@ -145,24 +145,26 @@ utils.checkVersion = function (callback) {
   
   //
   // Only allow the `checkVersion` function 200ms
-  // to attempt to contact GitHub.
+  // to attempt to contact npm.
   //
-  setTimeout(function () {
-    if (!responded) {
-      responded = true;
-      callback();
-    }
-  }, 200);
-  
   //
-  // Check the GitHub tags for `jitsu` to see if the current
+  // Check npm for `jitsu` to see if the current
   // version is outdated.
   //
   request({
-    uri: 'http://registry.npmjs.org/jitsu/latest'
+    uri: 'http://registry.npmjs.org/jitsu/latest',
+    timeout: 200
   }, function (err, res, body) {
-    if (!responded) {
-      responded = true;
+      if (err) { 
+        // 
+        // When using request's timeout option, the timeout comes through as 'ETIMEDOUT'.
+        // This aborts the request instead of waiting for the response.
+        // 
+        if (err !== 'ETIMEDOUT') { 
+          return callback(err); 
+        }
+        return callback(); 
+      }
       
       try {
         var pkg = JSON.parse(body);
@@ -174,12 +176,11 @@ utils.checkVersion = function (callback) {
       }
       catch (ex) {
         //
-        // Ignore errors from GitHub. We will notify the user
+        // Ignore errors from npm. We will notify the user
         // of an upgrade at the next possible opportunity.
         //
       }
 
       callback();
-    }
   });
 };


### PR DESCRIPTION
The state of the timeout being set in `jitsu.utils.checkVersion` was only being evaluated after the response came back - when dealing with high-latency connections, the amount of time involved is indeterminate.  This renders the `setTimeout` ineffective, as the process can hang, waiting for the response callback, for quite some time.

An alternative is to use the `timeout` option in `request`, which returns `ETIMEDOUT` when the timeout expires, thus aborting the request.

This was a partial cause of #70, but that issue is not yet fully resolved.
