### PR TITLE
Fixes to post-login-failure password resets

### DIFF
--- a/lib/jitsu.js
+++ b/lib/jitsu.js
@@ -216,7 +216,7 @@ jitsu.setupUserNoWarn = function(callback) {
       if (err) {
         return callback(err);
       }
-      if (/^y[es]*/i.test(res.reset)) {
+      if (/^y[es]?/i.test(res['request password reset'])) {
         return jitsu.commands.run(['users', 'forgot', username], callback);
       }
       

--- a/lib/jitsu/commands/users.js
+++ b/lib/jitsu/commands/users.js
@@ -231,7 +231,7 @@ users.forgot = function (username, shake, callback) {
     }
 
     winston.info('Check your email for instructions on resetting your password.');
-    callback();
+    callback(new Error('Password reset pending, cannot login.'));
   });
 };
 


### PR DESCRIPTION
This patch is meant to address two things.

First, when the `reset` prompt properties were moved to `properties.js`, the `property.name` changed from `reset` to `request password reset` - this was throwing off the match, and preventing the reset emails from ever getting sent.

Second, I was returning an error after the reset because of the way `Jitsu`'s call stack appears to work.  If one calls `callback` with no arguments, the command that `Jitsu` was attempting to run before asking for credentials is counted as having succeeded, which can lead to some genuinely strange UI messages.  This is the output if the callback is called without arguments:

```
  info:   Request password reset for: aviantestertwo
  info:   Check your email for instructions on resetting your password.
  info:   Successfully configured user aviantestertwo
  info:   Executing command list
  error:  Unable to Authenticate as aviantestertwo
  error:  Nodejitsu Error (403): Not Authorized
  info:   Nodejitsu not ok
```

If an error is returned, on the other hand:

```
  info:   Request password reset for: aviantestertwo
  info:   Check your email for instructions on resetting your password.
  error:  Error running command list
  info:   Nodejitsu not ok
```
