### PR TITLE
Database command prompts for database name/type

### DIFF
--- a/lib/jitsu/commands/databases.js
+++ b/lib/jitsu/commands/databases.js
@@ -61,6 +61,7 @@ databases.create = function (databaseType, databaseName, callback) {
     if (!databaseName) {
       callback = databaseType;
       promptFor = ['database type'].concat(promptFor);
+      winston.error('Valid database types are: `couch`, `redis` and `mongo`.');
     }
     else {
       callback = databaseName;
@@ -182,13 +183,13 @@ var printDatabase = function (database) {
       var subdomain = database.metadata.id.split('/')[1];
       winston.info('Database name: ' + database.name);
       winston.info('Database type: ' + database.type);
-      winston.info('Connection url: http://' + subdomain + '.couchone.com:5984');
+      winston.info('Connection url: ' + ('http://' + subdomain + '.couchone.com:5984').magenta);
       break;
 
     case 'mongo':
       winston.info('Database name: ' + database.name);
       winston.info('Database type: ' + database.type);
-      winston.info('Connection url: ' + database.metadata.config.MONGOHQ_URL);
+      winston.info('Connection url: ' + (database.metadata.config.MONGOHQ_URL).magenta);
       break;
 
     case 'redis':
@@ -198,7 +199,7 @@ var printDatabase = function (database) {
 
       winston.info('Database name: ' + database.name);
       winston.info('Database type: ' + database.type);
-      winston.info('Connection url: redis://nodejitsu:' +  password+ '@' + server + '.redistogo.com:' + port + '/');
+      winston.info('Connection url: ' + ('redis://nodejitsu:' +  password+ '@' + server + '.redistogo.com:' + port + '/').magenta);
       break;
 
     default:


### PR DESCRIPTION
This branch adds the following behavior:

```
josh@pidgey:~/jitsu$ jitsu databases create
info:   Welcome to Nodejitsu
info:   It worked if it ends with Nodejitsu ok
info:   Executing command databases create
info:   Authenticated as jesusabdullah
error:  You need to pass a database name and type
error:  jitsu databases create <database type> <database name>
prompt: database type: mongo
prompt: database name: another-mongo
info:   Database another-mongo was created.
info:   Database name: another-mongo
info:   Database type: mongo
info:   Connection url: ***
info:   Nodejitsu ok
```

If you try `jitsu databases create mongo` or similar, it will just prompt for the database name.

Fixes issue #93.
