### PR TITLE
[api] Added support for using Jitsu through a proxy server.

### DIFF
--- a/lib/jitsu/api/client.js
+++ b/lib/jitsu/api/client.js
@@ -37,21 +37,27 @@ Client.prototype.request = function (method, uri /* variable arguments */) {
       success = args.pop(),
       callback = args.pop(),
       body = typeof args[args.length - 1] === 'object' && !Array.isArray(args[args.length - 1]) && args.pop(),
-      encoded = jitsu.utils.base64.encode(this.options.get('username') + ':' + this.options.get('password'));
-  
+      encoded = jitsu.utils.base64.encode(this.options.get('username') + ':' + this.options.get('password')),
+      proxy = this.options.get('proxy'),
+      remoteUri = this.options.get('remoteUri');
+
   options = {
     method: method || 'GET',
-    uri: this.options.get('remoteUri') + '/' + uri.join('/'),
+    uri: (proxy || remoteUri) + '/' + uri.join('/'),
     headers: {
       'Authorization': 'Basic ' + encoded,
       'Content-Type': 'application/json'
     }
   };
-  
+
   if (body) {
     options.body = JSON.stringify(body);
   }
   
+  if (proxy) {
+    options.headers['host'] = remoteUri;
+  }
+
   this._request(options, function (err, response, body) {
     if (err) {
       return callback(err);
@@ -101,14 +107,16 @@ Client.prototype.upload = function (uri, contentType, file, callback, success) {
   var self = this,
       options, 
       out, 
-      encoded;
+      encoded,
+      proxy = this.options.get('proxy'),
+      remoteUri = this.options.get('remoteUri');
       
   encoded = jitsu.utils.base64.encode(this.options.get('username') + ':' + this.options.get('password'));
   
   fs.readFile(file, function (err, data) {
     options = {
       method: 'POST',
-      uri: self.options.get('remoteUri') + '/' + uri.join('/'),
+      uri: (proxy || remoteUri) + '/' + uri.join('/'),
       headers: {
         'Authorization': 'Basic ' + encoded,
         'Content-Type': contentType,
@@ -116,6 +124,10 @@ Client.prototype.upload = function (uri, contentType, file, callback, success) {
       }
     };
     
+    if (proxy) {
+      options.headers['host'] = remoteUri;
+    }
+
     out = self._request(options, function (err, response, body) {
       if (err) {
         return callback(err);


### PR DESCRIPTION
@pkumar was having trouble using jitsu from his university's network, so @dominictarr and I looked into the situation.

This patch adds support for a `proxy` property in `.jitsuconf`, which should be set to the hostname of the proxy server to be used.  If `proxy` is set, the request headers are adjusted accordingly.
