### PR TITLE
[api] Added support for using jitsu behind a proxy

### DIFF
--- a/lib/jitsu/api/client.js
+++ b/lib/jitsu/api/client.js
@@ -37,7 +37,8 @@ Client.prototype.request = function (method, uri /* variable arguments */) {
       success = args.pop(),
       callback = args.pop(),
       body = typeof args[args.length - 1] === 'object' && !Array.isArray(args[args.length - 1]) && args.pop(),
-      encoded = jitsu.utils.base64.encode(this.options.get('username') + ':' + this.options.get('password'));
+      encoded = jitsu.utils.base64.encode(this.options.get('username') + ':' + this.options.get('password')),
+      proxy = this.options.get('proxy');
   
   options = {
     method: method || 'GET',
@@ -50,6 +51,10 @@ Client.prototype.request = function (method, uri /* variable arguments */) {
   
   if (body) {
     options.body = JSON.stringify(body);
+  }
+  
+  if(proxy) {
+    options.proxy = proxy;
   }
   
   this._request(options, function (err, response, body) {
@@ -101,7 +106,8 @@ Client.prototype.upload = function (uri, contentType, file, callback, success) {
   var self = this,
       options, 
       out, 
-      encoded;
+      encoded,
+      proxy = self.options.get('proxy');
       
   encoded = jitsu.utils.base64.encode(this.options.get('username') + ':' + this.options.get('password'));
   
@@ -115,6 +121,10 @@ Client.prototype.upload = function (uri, contentType, file, callback, success) {
         'Content-Length': data.length
       }
     };
+    
+    if(proxy) {
+      options.proxy = proxy;
+    }
     
     out = self._request(options, function (err, response, body) {
       if (err) {


### PR DESCRIPTION
@AvianFlu pull request didn't help me with my problems for connecting through proxy server. So, I did a little digging of my own and came up with this solution.

It's working perfectly fine and I am now able to use jitsu and try out nodejitsu. (all from behind a proxy)
