### PR TITLE
.jitsuconf holds password in plain text

### DIFF
--- a/lib/jitsu/config.js
+++ b/lib/jitsu/config.js
@@ -115,7 +115,9 @@ config.findJitsuconf = function (filename) {
   }
 
   if (!configPath) {
-    fs.writeFileSync(configPath = path.join(process.env.HOME, filename), JSON.stringify(defaults, null, 2));
+    configPath = path.join(process.env.HOME, filename);
+    fs.writeFileSync(configPath, JSON.stringify(defaults, null, 2));
+    fs.chmodSync(configPath, 0600);
   }
 
   winston.silly('Using config file ' + configPath.magenta);


### PR DESCRIPTION
This is a hotfix to protect your nodejitsu password from other users.

```
chmod 0600 ~/.jitsuconf
```

Please consider rewriting the authentication process to work with API keys, or public/private key pairs. It always scares me to see plain text passwords.

I really like nodejitsu. Thank you guys!
