### PR TITLE
[api] Added body attr to options if empty body for POST, PUT & DELETE

### DIFF
--- a/lib/jitsu/api/client.js
+++ b/lib/jitsu/api/client.js
@@ -51,9 +51,13 @@ Client.prototype.request = function (method, uri /* variable arguments */) {
   
   if (body) {
     options.body = JSON.stringify(body);
+  } else {
+    if (method!='GET') {
+      options.body = '{}';
+    }
   }
   
-  if(proxy) {
+  if (proxy) {
     options.proxy = proxy;
   }
   


### PR DESCRIPTION
This patch fixes #109.

Activating snapshots is not the only thing which is not working. Any POST, PUT or DELETE request to an url with an empty body is not working. (Example: Deleting snapshot)

This pull request adds body attr as {} if there is an empty body for POST, PUT & DELETE.

Note: We should not add body for GET.
