### PR TITLE
[fix] Fix to prevent errors while prompting for new app or subdomain names

### DIFF
--- a/lib/jitsu/package.js
+++ b/lib/jitsu/package.js
@@ -452,7 +452,7 @@ package.properties = function (dir) {
 
 function tryAnalyze (target, dir, callback) {
   if (target.analyzed) {
-    return callback(false, target);
+    return callback(null, target);
   }
   
   var noanalyze = !((jitsu.config.get('analyze') === 'true')
@@ -506,8 +506,7 @@ function fillPackage (base, dir, callback) {
       // TODO: Something here...
       //
       winston.error('Unable to add properties to package description.');
-      callback(err);
-      return;
+      return callback(err);
     }
     
     result.scripts = result.scripts || {};
@@ -526,15 +525,20 @@ function fillPackage (base, dir, callback) {
           delete result.subdomain;
           fields.push('subdomain');
         }
-        props = descriptors.filter(function (d) {
-          return fields.indexOf(d.name) !== -1;
+        props = package.properties(dir).filter(function (p) {
+          return fields.indexOf(p.name) !== -1;
         });
-        winston.error(isAvailable.message);
+        if (fields.indexOf('name') !== -1) {
+          winston.error('The application name you have requested is already in use.');
+        }
+        if (fields.indexOf('subdomain') !== -1) {
+          winston.error('The subdomain you have requested is already in use.');
+        }
         jitsu.prompt.addProperties(result, props, createPackage);
         return;
       }
       
-      callback(false, result);
+      callback(null, result);
     });
   });
 }


### PR DESCRIPTION
This solves a minor scoping issue that was causing errors in `node-prompt`, and makes the error output a little clearer in cases where a user is attempting to use a name that is already in use.

This fixes #130.
