### PR TITLE
Hard coded "/" looks funny in windows. 

### DIFF
--- a/lib/jitsu/package.js
+++ b/lib/jitsu/package.js
@@ -130,7 +130,7 @@ package.create = function (dir, callback) {
   ];
 
   winston.warn('There in no valid package.json file in ' + dir.grey);
-  winston.warn('Creating package.json at ' + (dir + '/package.json').grey);
+  winston.warn('Creating package.json at ' + (path.join(dir, '/package.json')).grey);
 
   help.forEach(function (line) {
     winston.help(line);


### PR DESCRIPTION
Use path.join for a "pretty print" path cross platform.

Tested on node 0.6.4 on windows7. prints correctly.

There are no more string literals like this in packages.js file but there may be more throughout the codebase.
