### PR TITLE
'jitsu config set' now supports Booleans. Fixes #145

### DIFF
--- a/lib/jitsu/commands/config.js
+++ b/lib/jitsu/commands/config.js
@@ -37,7 +37,7 @@ config.set = function (key, value, callback) {
     return callback(true, true);
   }
   
-  jitsu.config.set(key, value)
+  jitsu.config.setFromString(key, value)
   jitsu.config.save(callback);
 };
 

--- a/lib/jitsu/config.js
+++ b/lib/jitsu/config.js
@@ -39,6 +39,32 @@ var defaults = {
 };
 
 //
+// ### function setFromString (key, value)
+// #### @key {string} Key to set in this instance
+// #### @value {string} Value for the specified key. The string will be parsed if the default value for they key is not an string. Custom keys will be assumed to be strings literals.
+// Sets the `value` for the specified configuration `key`.
+//
+
+config.setFromString = function(key, value) {
+  // Check if the expected value needs to be parsed based on the default type for the given key.
+  var keyType = typeof(defaults[key]); 
+  if(keyType !== 'undefined' && keyType !== 'string') {
+    // It's not an string, we need to parse the value.
+    var newArgs = Array.prototype.slice.call(arguments);
+    try {
+      value = JSON.parse(value); // Set the 'value' argument with the parsed version.
+    } catch(e) {
+      // Something went wrong
+      throw ['Config key ', key, ' is expecting value to be of type ', keyType].join('');
+    }
+    this.set.call(this, key, value);
+  } else {
+    // It's a custom key, let's just set the value.
+    this.set.call(this, key, value);
+  }
+}
+
+//
 // Make sure the file exists if it was set explicitly
 //
 config.findJitsuconf = function (filename) {


### PR DESCRIPTION
With this patch `jitsu config set analyze false` will properly set the value in .jitsuconf as `boolean` instead of `string`.

From now on `jitsu config set` will parse all the values except when the default value for the configuration key is string or there is no default value for the configuration key.
