### PR TITLE
Change default tmproot to avoid writing-to-/tmp permission errors

### DIFF
--- a/lib/jitsu/config.js
+++ b/lib/jitsu/config.js
@@ -31,7 +31,7 @@ var defaults = {
   'loglength': 110,
   'userconfig': '.jitsuconf',
   'loglevel': 'info',
-  'tmproot': process.env.HOME + '/.jitsu',
+  'tmproot': process.env.HOME + '/.jitsu/tmp',
   'tar': 'tar',
   'colors': true,
   'analyze': true,


### PR DESCRIPTION
We've had some users complaining about jitsu erroring out because certain configurations don't allow for writing to /tmp. As part of a solution, I propose that we change the default directory for temporary file writes to `~/.jitsu`.

Truth be told, I prefer writing to /tmp conceptually, but I'd rather write somewhere else if it means that less users have difficulty.

Another thing to consider: If we write to /tmp it will get auto-cleaned on reboot. I don't think we can count on that for `~/.jitsu`, so adopting this change would mean having to think about cleanup.
