### PR TITLE
Use iriscouch.com instead of couchone.com and return the SSL connection URL.

### DIFF
--- a/lib/jitsu/commands/databases.js
+++ b/lib/jitsu/commands/databases.js
@@ -174,7 +174,8 @@ var printDatabase = function (database) {
       var subdomain = database.metadata.id.split('/')[1];
       jitsu.log.info('Database name: ' + database.name);
       jitsu.log.info('Database type: ' + database.type);
-      jitsu.log.info('Connection url: ' + ('http://' + subdomain + '.couchone.com:5984').grey);
+      jitsu.log.info('Connection url: ' + ('http://' + subdomain + '.iriscouch.com:5984').grey);
+      jitsu.log.info('SSL connection url: ' + ('https://' + subdomain + '.iriscouch.com:6984').grey);
       break;
 
     case 'mongo':


### PR DESCRIPTION
But it's on the flatiron branch this time. 8D
