### PR TITLE
[fix api] Only properties that need to be unique across applications require an availability check.

### DIFF
--- a/lib/jitsu/package.js
+++ b/lib/jitsu/package.js
@@ -175,6 +175,7 @@ package.validate = function (pkg, dir, options, callback) {
     }
 
     if (!value || (missing.validator && !missing.validator.test(value))) {
+
       missing.push(desc);
     }
 
@@ -420,12 +421,14 @@ package.properties = function (dir) {
   return [
     {
       name: 'name',
+      unique: true,
       message: 'App name',
       validator: /[\w|\-]+/,
       default: path.basename(dir)
     },
     {
       name: 'subdomain',
+      unique: true,
       validator: /[\w|\-|\_]+/,
       help: [
         '',
@@ -452,11 +455,13 @@ package.properties = function (dir) {
     },
     {
       name: 'version',
+      unique: false,
       validator: semver.valid,
       default: '0.0.0'
     },
     {
       name: 'engines.node',
+      unique: false,
       message: 'engines',
       validator: semver.validRange,
       default: process.version.split('.').slice(0, 2).join('.') + '.x'
@@ -473,12 +478,14 @@ package.properties = function (dir) {
 // Prompts for appname and subdomain until the combination is available
 //
 package.available = function (pkg, dir, callback, createPackage) {
+
   jitsu.apps.available(pkg, function (err, isAvailable) {
     var props, fields = [];
     if (err) {
       jitsu.log.error('There was an error while checking app name / subdomain availability.');
       return callback(err);
     }
+
     if (!isAvailable.available) {
       if (isAvailable.appname === false) {
         delete pkg.name;
@@ -558,26 +565,39 @@ function fillPackage (base, dir, callback) {
   if (!(base.engines && base.engines.node)){
     missing.push('engines.node');
   }
+
+  //missing = missing.filter(function(m) {
+  //  package.properties(dir)
+  //});// TODO
   
   descriptors = package.properties(dir).filter(function (descriptor) {
     if (descriptor.name == 'subdomain') {
       subdomain = descriptor;
     }
-    
+
     return missing.indexOf(descriptor.name) !== -1;
   });
-  
+
   jitsu.prompt.addProperties(base, descriptors, function createPackage (err, result) {
+
     if (err) {
       //
       // TODO: Something here...
       //
       jitsu.log.error('Unable to add properties to package description.');
-      console.error(err);
       return callback(err);
     }
-    
+
+    var isUnique = descriptors.filter(function (descriptor) {
+      return descriptor.unique;
+    }).length;
+
     result.scripts = result.scripts || {};
-    package.available(result, dir, callback, createPackage);
+    if (isUnique) {
+      package.available(result, dir, callback, createPackage);
+    }
+    else {
+      callback(null, result); // TODO
+    }
   });
 }


### PR DESCRIPTION
In the case of `subdomain` and `name` need an availability check when missing. In the cases of scripts.start and engines.node, it could just be that they're missing from the app.

This fixes an issue where users whose apps did not have engines fields originally were being told their app was already taken.
