### PR TITLE
[fix] Version comparison regression

### DIFF
--- a/lib/jitsu/commands/apps.js
+++ b/lib/jitsu/commands/apps.js
@@ -139,7 +139,10 @@ apps.deploy = function (callback) {
         }
       }
       else {
-        pkg = analyzer.merge({}, local, { version: app.version });
+        app = app
+          ? { version: app.version }
+          : {};
+        pkg = analyzer.merge({}, local, app);
         jitsu.package.validate(pkg, dir, updateSnapshot);
       }
     });


### PR DESCRIPTION
Originally caused by: 68ec5cceb61c9414a85a8e99a19012b7c30d9d46

Jitsu ends up comparing the local package.json version to itself. This results
in jitsu thinking the user's app needs a version bump everytime `deploy` is
executed. This commit ensures the remote package.json's version gets merged in.

Closes #209.
