### PR TITLE
Attempting to jitsu deploy when not logged in, should prompt login

### DIFF
--- a/lib/jitsu/commands/apps.js
+++ b/lib/jitsu/commands/apps.js
@@ -41,7 +41,20 @@ apps.usage = [
 //
 apps.deploy = function (callback) {
   var dir = process.cwd(), pkg;
-  
+
+  function promptLogin() {
+     jitsu.log.warn("You are not logged in.")
+     jitsu.log.warn("Please authenticate first.")
+     jitsu.commands.users.login(callback)
+   }
+
+  //
+  // if not logged in require the user to authenticate before deploying
+  //
+  if (!jitsu.config.get('username') && !jitsu.config.get('password')) {
+     return promptLogin();
+  }
+
   //
   // Allows arbitrary amount of arguments to deploy
   //


### PR DESCRIPTION
referencing issue #224

This will stop an unauthenticated user and require them to login before doing a `jitsu deploy`
