### PR TITLE
[fix] issue #241 (jitsu env set would set null: null)

### DIFF
--- a/lib/jitsu/commands/env.js
+++ b/lib/jitsu/commands/env.js
@@ -30,7 +30,15 @@ env.usage = [
 // the application in the current directory.
 //
 env.set = function (appName, key, value, callback) {
+
   if (value === null) {
+		if (key === null) {
+		  jitsu.log.error(
+        'You must specify both an environment variable name and value.'
+      );
+      return callback({});
+		}
+
     value = key;
     key = appName;
     return viewApp(callback, update);
@@ -39,6 +47,7 @@ env.set = function (appName, key, value, callback) {
   viewAppByName(appName, callback, update);
   
   function update(err, app) {
+
     app.env = app.env || {};
     app.env[key] = value;
     jitsu.apps.update(app.name, { env: app.env }, callback);

--- a/test/commands/env-test.js
+++ b/test/commands/env-test.js
@@ -135,6 +135,14 @@ vows.describe('jitsu/commands/env').addBatch({
       }, { 'x-powered-by': 'Nodejitsu' })
   })
 }).addBatch({
+  'env set': shouldNodejitsuOk(
+    'Should exit with an error',
+    function assertion (ign, err) {
+      err = ign;
+      assert.isTrue(!!err);
+    }
+  )
+}).addBatch({
   'env set test truthy': shouldNodejitsuOk(function setup() {
     nock('http://api.mockjitsu.com')
       .get('/apps/tester/jitsu')


### PR DESCRIPTION
Includes both a fix and a test.

Right now it exits, demanding that you specify a key and value. Alternate behavior would be to prompt for the key and value, or to display help for `jitsu env`. Thoughts?

Refer to: https://github.com/nodejitsu/jitsu/issues/241
