### PR TITLE
[fix] exists and existsSync fixes

### DIFF
--- a/lib/jitsu/commands/install.js
+++ b/lib/jitsu/commands/install.js
@@ -7,6 +7,7 @@
  
 var fs = require('fs'),
     path = require('path'),
+    exists = fs.exists || path.exists,
     common = require('../common'),
     cpr = common.cpr,
     rimraf = common.rimraf,
@@ -173,7 +174,7 @@ module.exports = function (requestedApp, callback) {
     // Check if the app provides any configuration schema
     //
     app.config.schemaPath = './' + app.name + '/config/schema.json';
-    path.exists(app.config.schemaPath, function (exists) {
+    exists(app.config.schemaPath, function (exists) {
       if (exists) {
         try {
           app.config.schema = JSON.parse(fs.readFileSync(app.config.schemaPath).toString());

--- a/lib/jitsu/package.js
+++ b/lib/jitsu/package.js
@@ -7,6 +7,7 @@
 
 var fs = require('fs'),
     path = require('path'),
+    existsSync = fs.existsSync || path.existsSync,
     util = require('util'),
     spawnCommand = require('spawn-command'),
     async = require('flatiron').common.async,
@@ -653,7 +654,7 @@ package.runScript = function (pkg, action, callback) {
 function searchStartScript(dir) {
   var scripts = ['server.js', 'bin/server', 'app.js', 'index.js'];
   for (i in scripts) {
-    if (path.existsSync(path.join(dir, scripts[i]))) {
+    if (existsSync(path.join(dir, scripts[i]))) {
       return scripts[i];
     }
   }


### PR DESCRIPTION
Fixes the two cases of path.exists/existsSync found [by the migrator bot](https://github.com/nodejitsu/jitsu/pull/264) in a backwards-compatible way.
