### PR TITLE
[fix] Fixed a regression due to prompt new version, very rare

### DIFF
--- a/lib/jitsu/package.js
+++ b/lib/jitsu/package.js
@@ -517,7 +517,7 @@ package.properties = function (dir) {
     {
       name: 'scripts.start',
       message: 'scripts.start',
-      validator: function (script) {
+      conform: function (script) {
         //
         // Support `scripts.start` starting with executable (`node` or `coffee`).
         //


### PR DESCRIPTION
### Before

```
➤  jitsu deploy
info:    Welcome to Nodejitsu pkumar
info:    It worked if it ends with Nodejitsu ok
info:    Executing command deploy
warn:    
warn:    Your package.json file is missing required fields:
warn:    
warn:      subdomain,   scripts.start
warn:    
warn:    Prompting user for required fields.
warn:    Press ^C at any time to quit.
warn:    
prompt: subdomain: (pkumar.jitsu) 
prompt: scripts.start: server.js
error:   Unable to add properties to package description.
error:   [TypeError: Object function (script) {
        //
        // Support `scripts.start` starting with executable (`node` or `coffee`).
        //
        var split = script.split(' ');
        if (~['node', 'coffee'].indexOf(split[0])) {
          script = split.slice(1).join(' ');
        }

        try {
          fs.statSync(path.join(dir, script));
          return true;
        }
        catch (ex) {
          return false;
        }
      } has no method 'test']
error:   TypeError: Object function (script) {
        //
        // Support `scripts.start` starting with executable (`node` or `coffee`).
        //
        var split = script.split(' ');
        if (~['node', 'coffee'].indexOf(split[0])) {
          script = split.slice(1).join(' ');
        }

        try {
          fs.statSync(path.join(dir, script));
          return true;
        }
        catch (ex) {
          return false;
        }
      } has no method 'test'
error:   Error running command deploy
info:    Nodejitsu not ok
```
### After

```
➤  jitsu deploy
info:    Welcome to Nodejitsu pkumar
info:    It worked if it ends with Nodejitsu ok
info:    Executing command deploy
warn:    
warn:    Your package.json file is missing required fields:
warn:    
warn:      subdomain,   scripts.start
warn:    
warn:    Prompting user for required fields.
warn:    Press ^C at any time to quit.
warn:    
prompt: subdomain: (pkumar.jitsu) 
prompt: scripts.start: server.js
error:   Invalid input for scripts.start
error:   Start script was not found in /home/pksunkara/Coding/nodejitsu/jitsu
prompt: scripts.start: ^C
```
