### PR TITLE
Arg currying congruity jul 2012

### DIFF
--- a/lib/jitsu/commands/apps.js
+++ b/lib/jitsu/commands/apps.js
@@ -7,7 +7,7 @@
 
 var analyzer = require('require-analyzer'),
     jitsu    = require('../../jitsu'),
-    utile    = require('utile');
+    utile    = jitsu.common;
 
 var apps = exports;
 

--- a/lib/jitsu/commands/databases.js
+++ b/lib/jitsu/commands/databases.js
@@ -6,7 +6,7 @@
  */
 
 var jitsu = require('../../jitsu'),
-    utile = require('utile');
+    utile = jitsu.common;
 
 var databases = exports;
 

--- a/lib/jitsu/commands/env.js
+++ b/lib/jitsu/commands/env.js
@@ -6,7 +6,7 @@
  */
 
 var jitsu = require('../../jitsu'),
-    utile = require('utile');
+    utile = jitsu.common;
 
 var env = exports;
 

--- a/lib/jitsu/commands/install.js
+++ b/lib/jitsu/commands/install.js
@@ -14,7 +14,7 @@ var fs = require('fs'),
     npmModule = require('npm'),
     wizard = require('wizard'),
     jitsu = require('../../jitsu'),
-    utile = require('utile');
+    utile = jitsu.common;
 
 //
 // "nodeapps" is a hash of aliases and npm packages,

--- a/lib/jitsu/commands/logs.js
+++ b/lib/jitsu/commands/logs.js
@@ -8,7 +8,7 @@
 var jitsu = require('../../jitsu'),
     dateformat = require('dateformat'),
     logs = exports,
-    utile = require('utile');
+    utile = jitsu.common;
 
 logs.usage = [
   'The `jitsu logs` commands allow you to read the logs related to your app.',

--- a/lib/jitsu/commands/package.js
+++ b/lib/jitsu/commands/package.js
@@ -6,7 +6,7 @@
  */
 
 var jitsu = require('../../jitsu'),
-    utile = require('utile');
+    utile = jitsu.common;
 
 var package = exports;
 

--- a/lib/jitsu/commands/snapshots.js
+++ b/lib/jitsu/commands/snapshots.js
@@ -9,7 +9,7 @@ var fs         = require('fs'),
     semver     = require('semver'),
     dateformat = require('dateformat'),
     jitsu      = require('../../jitsu'),
-    utile      = require('utile');
+    utile      = jitsu.common;
 
 var snapshots = exports;
 

--- a/lib/jitsu/commands/users.js
+++ b/lib/jitsu/commands/users.js
@@ -7,7 +7,7 @@
 
 var jitsu = require('../../jitsu'),
     users = exports,
-    utile = require('utile');
+    utile = jitsu.common;
 
 //
 // ### function confirm (username, callback)

--- a/lib/jitsu/commands/wizard.js
+++ b/lib/jitsu/commands/wizard.js
@@ -12,7 +12,7 @@ var fs        = require('fs'),
     rimraf    = common.rimraf,
     npmModule = require('npm'),
     jitsu     = require('../../jitsu'),
-    utile     = require('utile');
+    utile     = jitsu.common;
 
 var thisPath  = process.cwd();
 


### PR DESCRIPTION
Adresses issue #281 (added a todo comment for #285)

Normalizes argument currying all throughout the jitsu cli tool using utile, so no more errors like the following from too many arguments, which results in an argument getting mistaken as a callback.

``` shell
blakmatrix@redmorpheus: ~/projects/jitsu arg_currying_congruity_jul_2012
$ jitsu list some_user _i_should_be_ignored                                                                                                      [20:04:11]
info:    Welcome to Nodejitsu blakmatrix
info:    It worked if it ends with Nodejitsu ok
info:    Executing command list some_user _i_should_be_ignored
info:    Listing all apps for some_user
error:   blakmatrix is not authorized to list applications for user: some_user

/usr/local/lib/node_modules/jitsu/lib/jitsu/commands/apps.js:290
      return callback(err);
             ^
TypeError: string is not a function
    at String.CALL_NON_FUNCTION (native)
    at /usr/local/lib/node_modules/jitsu/lib/jitsu/commands/apps.js:290:14
    at Request._callback (/usr/local/lib/node_modules/jitsu/node_modules/nodejitsu-api/lib/client/client.js:106:14)
    at Request.callback (/usr/local/lib/node_modules/jitsu/node_modules/nodejitsu-api/node_modules/request/main.js:104:22)
    at Request.<anonymous> (/usr/local/lib/node_modules/jitsu/node_modules/nodejitsu-api/node_modules/request/main.js:458:18)
    at Request.emit (events.js:67:17)
    at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/jitsu/node_modules/nodejitsu-api/node_modules/request/main.js:423:16)
    at IncomingMessage.emit (events.js:88:20)
    at HTTPParser.parserOnMessageComplete [as onMessageComplete] (http.js:130:23)
    at CleartextStream.socketOnData [as ondata] (http.js:1288:20)
FAIL: 1

```

also fixed some jshint, missing semicolons, and unnecessary white-space along the way.
