### PR TITLE
fixes #297 - update database Redis example usage

### DIFF
--- a/lib/jitsu/commands/databases.js
+++ b/lib/jitsu/commands/databases.js
@@ -344,7 +344,7 @@ var printDbHelp = function (database) {
         'Connect with the `' + 'redis'.magenta + '` module:',
         '',
         '    var redis = require(\'redis\');',
-        '    var client = redis.createClient(\'' + server + '\', ' + port + ');',
+        '    var client = redis.createClient(' + port + ', \'' + server + '\');',
         '    client.auth(\'' + password + '\', function (err) {',
         '      if (err) { throw err; }',
         '      // You are now connected to your redis.',


### PR DESCRIPTION
createClient expects **port, server** instead of **server, port**

```
var client = redis.createClient(9723, 'chubb.redistogo.com');
```
