### PR TITLE
Fix path for installing npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## One-line npm install
 
-    [sudo] curl http://npmjs.org/install.sh | sh
+    [sudo] curl https://npmjs.org/install.sh | sh
 
 
 ## One-line jitsu install


### PR DESCRIPTION
The path for npm is incorrect. When curling it, it refers you to https.

``` bash
$ sudo curl http://npmjs.org/install.sh | sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0    85    0    85    0     0    138      0 --:--:-- --:--:-- --:--:--   858
sh: line 1: syntax error near unexpected token `newline'
sh: line 1: `<html>Moved: <a href="https://npmjs.org/install.sh">https://npmjs.org/install.sh</a>
```
