### PR TITLE
fix crash

### DIFF
--- a/lib/jitsu/package.js
+++ b/lib/jitsu/package.js
@@ -295,9 +295,9 @@ package.write = function (pkg, dir, create, callback) {
     }
     
     fs.readFile(path.resolve(path.join(dir, 'package.json')), function(e, data) {
-      var offset = ladder(data.toString()); 
+      var offset = data ? ladder(data.toString()) : 2;
       
-      fs.writeFile(path.join(dir, 'package.json'), JSON.stringify(pkg, null, offset || 2), function (err) {
+      fs.writeFile(path.join(dir, 'package.json'), JSON.stringify(pkg, null, offset), function (err) {
         return err ? callback(err) : callback(null, pkg, dir);
       });
     });


### PR DESCRIPTION
if the package.json doesn't exist, jitsu tries to read it and crashes
