### PR TITLE
Fix sort logs

### DIFF
--- a/lib/jitsu/commands/logs.js
+++ b/lib/jitsu/commands/logs.js
@@ -62,7 +62,7 @@ logs.all = function (amount, callback) {
     }
 
     Object.keys(apps).sort(sortLength).forEach(function (app) {
-      console.log('App: '.gray + app.purple);
+      console.log('App: '.grey + app.magenta);
       putLogs(apps[app], app, amount, true);
     });
 


### PR DESCRIPTION
Issue #328

I have a question though.. when someone tries `jitsu logs all`, jitsu would output logs for each app, so logs would be from newest to oldest in each singular app, but not entirely.. example

```
[yawn@xolotl lolz]$ jitsu logs all
info:    Welcome to Nodejitsu yawn
info:    jitsu v0.9.8, node v0.8.11
info:    It worked if it ends with Nodejitsu ok
info:    Executing command logs all
warn:    No logs for Narwhal in specified timespan
warn:    No logs for owl in specified timespan
// FIRST APP HERE
[10/01 16:53:41 GMT+0200] GET / 200 3182ms - 6.13kb
[10/01 16:53:38 GMT+0200] GET /robots.txt 404 1ms
[10/01 16:23:47 GMT+0200] GET /stylesheets/style.css 304 1ms
[10/01 16:23:47 GMT+0200] GET /javascripts/code.js 304 1ms
[10/01 16:23:47 GMT+0200] GET / 200 200ms - 6.13kb
[10/01 16:22:50 GMT+0200] GET /stylesheets/style.css 200 5ms - 214
[10/01 16:22:50 GMT+0200] GET /javascripts/code.js 200 6ms - 312
[10/01 16:22:50 GMT+0200] GET /errors/1e7c7397-c06f-45d6-ac93-e6642b2d54fb/edit 200 3175ms - 4.39kb
// SECOND APP HERE
[10/01 22:41:22 GMT+0200] [Error: failed to connect to [alex.mongohq.com:10086]]
[10/01 22:40:50 GMT+0200] [Error: failed to connect to [alex.mongohq.com:10086]]
[10/01 22:39:07 GMT+0200] Error: ENOENT, no such file or directory
[10/01 22:39:07 GMT+0200]     at Function.startup.resolveArgv0 (node.js:536:23)
[10/01 22:39:07 GMT+0200]     at startup (node.js:54:13)
[10/01 22:39:07 GMT+0200]     at node.js:627:3
[10/01 22:39:07 GMT+0200] node.js:536
[10/01 22:39:07 GMT+0200]     var cwd = process.cwd();
[10/01 22:39:07 GMT+0200]                       ^
[10/01 22:36:16 GMT+0200] {"NSsOo":"value","_id":"5069fec04765827e71000001"}
// THIRD APP HERE
[10/01 20:53:53 GMT+0200] {"zzxf3":"value","_id":"5069e6be26dc47782e000001"}
[10/01 20:52:53 GMT+0200] {"lSv3w":"value","_id":"5069e685bf2ce0d12d000001"}
[10/01 20:51:23 GMT+0200] Error: EEXIST, file already exists
[10/01 20:51:23 GMT+0200]     at Function.startup.resolveArgv0 (node.js:536:23)
[10/01 20:51:23 GMT+0200]     at startup (node.js:54:13)
[10/01 20:51:23 GMT+0200]     at node.js:627:3
[10/01 20:51:23 GMT+0200] node.js:536
[10/01 20:51:23 GMT+0200]     var cwd = process.cwd();
[10/01 20:51:23 GMT+0200]                       ^
info:    Nodejitsu ok
```
