### PR TITLE
[fix] _bytesDispatched 

### DIFF
--- a/lib/jitsu/package.js
+++ b/lib/jitsu/package.js
@@ -428,7 +428,9 @@ package.updateTarball = function (version, pkg, existing, firstSnapshot, callbac
         });
         
         if(emitter) { 
+          var size;
           emitter.on('start', function(stats) {
+            size = stats.size;
             bar = new ProgressBar('info'.green + '\t Uploading: [:bar] :percent',{
               complete  : '=',
               incomplete: ' ',
@@ -438,7 +440,7 @@ package.updateTarball = function (version, pkg, existing, firstSnapshot, callbac
           });
 
           emitter.on('data', function(length) {
-            if(bar) bar.tick(length);
+            if(bar) bar.tick(length > size ? size : length);
           });
 
           emitter.on('end', function() {


### PR DESCRIPTION
bytesDispatched sometimes is a bigger number than the package's size, and that crashes the progressBar
