### PR TITLE
Always prompt yes/no on app destruction

### DIFF
--- a/lib/jitsu/commands/apps.js
+++ b/lib/jitsu/commands/apps.js
@@ -543,7 +543,7 @@ apps.update.usage = [
 //
 apps.destroy = function (name, callback) {
 
-//
+  //
   // Allows arbitrary amount of arguments
   //
   if(arguments.length) {
@@ -551,32 +551,30 @@ apps.destroy = function (name, callback) {
     callback = args.callback;
     name = args[0] || null;
   }
-
-  function executeDestroy() {
-    jitsu.log.info('Destroying app ' + name.magenta);
-    jitsu.apps.destroy(name, function (err) {
-      jitsu.log.silly('Done destroying app ' + name.magenta);
-      return err ? callback(err) : callback();
-    });
-  }
-
   if (!name) {
     jitsu.package.tryRead(process.cwd(), callback, function (pkg) {
       jitsu.log.info('Attempting to destroy app ' + pkg.name.magenta);
       name = pkg.name;
-      jitsu.prompt.confirm('yes/no', function(err, result){
-        if (result) {
-          executeDestroy();
-        } else {
-          jitsu.log.info('app ' + pkg.name.magenta + ' was not destroyed');
-          callback(null);
-        }
-      });
+      executeDestroy();
     });
   } else {
     executeDestroy();
   }
 
+  function executeDestroy() {
+    jitsu.log.info('Destroy app ' + name.magenta);
+    jitsu.prompt.confirm('yes/no', { default: 'yes'}, function(err, result){
+      if (result) {
+        jitsu.apps.destroy(name, function (err) {
+          jitsu.log.silly('Done destroying app ' + name.magenta);
+          return err ? callback(err) : callback();
+        });
+      } else {
+        jitsu.log.info('app ' + name.magenta + ' was not destroyed');
+        callback(null);
+      }
+    });
+  }
 };
 
 //


### PR DESCRIPTION
Currently app destruction is only confirmed when a user runs `jitsu apps destroy` or `jitsu destroy`, whereas when you specify an app (ex. `jitsu destroy helloworld`) it does not prompt for destruction.
