### PR TITLE
[minor] Add `publish` as alias for `jitsu deploy`.

### DIFF
--- a/lib/jitsu/alias.js
+++ b/lib/jitsu/alias.js
@@ -4,7 +4,7 @@
  * (C) 2010, Nodejitsu Inc.
  *
  */
- 
+
 var jitsu = require('../jitsu');
 
 //
@@ -12,6 +12,7 @@ var jitsu = require('../jitsu');
 //
 jitsu.alias('destroy', { resource: 'apps',   command: 'destroy' });
 jitsu.alias('deploy',  { resource: 'apps',   command: 'deploy' });
+jitsu.alias('publish', { resource: 'apps',   command: 'deploy' });
 jitsu.alias('d',       { resource: 'apps',   command: 'deploy' });
 jitsu.alias('push',    { resource: 'apps',   command: 'deploy' });
 jitsu.alias('list',    { resource: 'apps',   command: 'list' });


### PR DESCRIPTION
I'm to used to typing `npm publish` so this feels like a natural addition.
