### PR TITLE
Fixes jitsu not reporting new version

### DIFF
--- a/lib/jitsu.js
+++ b/lib/jitsu.js
@@ -141,16 +141,16 @@ jitsu.start = function (callback) {
     return;
   }
 
-  jitsu.common.checkVersion(function (err) {
+  jitsu.init(function (err) {
     if (err) {
-      return callback();
+      jitsu.welcome();
+      callback(err);
+      return jitsu.showError(jitsu.argv._.join(' '), err);
     }
-    
-    jitsu.init(function (err) {
+
+    jitsu.common.checkVersion(function (err) {
       if (err) {
-        jitsu.welcome();
-        callback(err);
-        return jitsu.showError(jitsu.argv._.join(' '), err);
+        return callback();
       }
 
       //

--- a/lib/jitsu/common/index.js
+++ b/lib/jitsu/common/index.js
@@ -173,7 +173,7 @@ common.checkVersion = function (callback) {
   //
   request({
     uri: 'http://registry.npmjs.org/jitsu/latest',
-    timeout: 400
+    timeout: 1000
   }, function (err, res, body) {
     if (!responded) {
       responded = true;


### PR DESCRIPTION
- Using the jitsu.log before init was making the code throw.
  Since it was in a try catch we never noticed.
  Until now...

![Stare Dad](http://cdn.superbwallpapers.com/wallpapers/meme/staredad-9237-400x250.jpg)
