### PR TITLE
Running jitsu without arguments results in TypeError

### DIFF
--- a/lib/jitsu.js
+++ b/lib/jitsu.js
@@ -229,6 +229,11 @@ jitsu.exec = function (command, callback) {
       command[1] = 'set';
       command[2] = 'remoteHost';
     }
+    
+    // Make sure the array can be join()'ed, if there are no arguments provided
+    if(command.length === 0) {
+      command.push('');
+    }
 
     jitsu.log.info('Executing command ' + command.join(' ').magenta);
     jitsu.router.dispatch('on', command.join(' '), jitsu.log, function (err, shallow) {


### PR DESCRIPTION
Solving the issue of running jitsu without arguments:

patrick$ jitsu
info:    Welcome to Nodejitsu user
info:    jitsu v0.12.4, node v0.10.0
info:    It worked if it ends with Nodejitsu ok
info:    Executing command 
info:    Welcome to Nodejitsu user
info:    jitsu v0.12.4, node v0.10.0
info:    It worked if it ends with Nodejitsu ok
info:    Executing command 

TypeError: Arguments to path.join must be strings
    at path.js:360:15
    at Array.filter (native)
    at Object.exports.join (path.js:358:36)
    at loadCommand (/usr/local/share/npm/lib/node_modules/jitsu/node_modules/flatiron/lib/flatiron/plugins/cli.js:211:45)
    at executeCommand (/usr/local/share/npm/lib/node_modules/jitsu/node_modules/flatiron/lib/flatiron/plugins/cli.js:278:26)
    at Object.app.router.notfound (/usr/local/share/npm/lib/node_modules/jitsu/node_modules/flatiron/lib/flatiron/plugins/cli.js:357:5)
    at Router.dispatch (/usr/local/share/npm/lib/node_modules/jitsu/node_modules/flatiron/node_modules/director/lib/director/cli.js:50:21)
    at execCommand (/usr/local/share/npm/lib/node_modules/jitsu/lib/jitsu.js:234:18)
    at jitsu.exec (/usr/local/share/npm/lib/node_modules/jitsu/lib/jitsu.js:247:54)
    at /usr/local/share/npm/lib/node_modules/jitsu/lib/jitsu.js:190:20
