### PR TITLE
jitsu install ghost

### DIFF
--- a/lib/jitsu/commands/install.js
+++ b/lib/jitsu/commands/install.js
@@ -36,27 +36,12 @@ var nodeapps = {
   "http-server": {
     "package": "http-server",
     "description": "  a robust and customizable http server"
+  },
+  "ghost": {
+    "package": "persistent-ghost",
+    "description": "        the ghost blogging platform with MongoDB persistence"
   }
 };
-
-
-/*
-
-"web-http-client": {
-  "package": "web-http-client",
-  "description": "web based http-client ( with server-side proxy )"
-},
-"custom-vimeo-site": {
-  "package": "custom-vimeo-site",
-  "description": "custom homepage for your vimeo videos"
-},
-
-"my-nodeapps": {
-  "package": "nodeapps-my-nodeapps",
-  "description": "simple site to display your node apps"
-}
-
-*/
 
 module.exports = function (requestedApp, callback) {
   //
@@ -90,17 +75,17 @@ module.exports = function (requestedApp, callback) {
   });
 
   function createApp(results, cb) {
-    if (Object.keys(nodeapps).indexOf(results['starter']) === -1) {
-      jitsu.log.error('Sorry, ' + results['starter'].magenta + ' is not a node app');
+    if (Object.keys(nodeapps).indexOf(results.starter) === -1) {
+      jitsu.log.error('Sorry, ' + results.starter.magenta + ' is not a node app');
       return cb('err');
     }
-    installApp(results['starter'], function (err, res) {
-      return err ? cb(err) : postInstall(results['starter'], cb);
+
+    installApp(results.starter, function (err, res) {
+      return err ? cb(err) : postInstall(results.starter, cb);
     });
   }
 
   function installApp(appName, cb) {
-
     var thisPath = process.cwd();
 
     jitsu.log.info('Installing ' + appName.magenta + ' locally');
@@ -111,7 +96,6 @@ module.exports = function (requestedApp, callback) {
       }
 
       cpr(path.join(thisPath + '/' + appName, 'node_modules', nodeapps[appName].package), thisPath + '/' + appName, function (err) {
-
         if (err) {
           return cb(err);
         }
@@ -119,11 +103,14 @@ module.exports = function (requestedApp, callback) {
         //
         // Read current package.json
         //
-        var pkg = JSON.parse(fs.readFileSync(thisPath + '/' + appName + '/package.json').toString());
+        var pkg = JSON.parse(fs.readFileSync(thisPath + '/' + appName + '/package.json').toString()),
+            installhook = pkg['jitsu-install'];
 
         //
-        // Strip out any un-needed internal ids
+        // Strip out any un-needed internal ids and our custom `jitsu-install`
+        // hook.
         //
+        delete pkg['jitsu-install'];
         for(var k in pkg) {
           if (k.search("_") !== -1) {
             delete pkg[k];
@@ -135,16 +122,23 @@ module.exports = function (requestedApp, callback) {
         //
         fs.writeFileSync(thisPath + '/' + appName + '/package.json', JSON.stringify(pkg, true, 2));
 
-        return cb(err, result);
+        if (!installhook) return cb(err, result);
+
+        //
+        // We got a custom `jitsu install` hook that needs to be ran.
+        //
+        require(thisPath + '/' + appName + '/'+ installhook)(jitsu, function (err) {
+          cb(err, result);
+        });
       });
     });
   }
 
   function promptforAppName(cb) {
-
     jitsu.log.help('The ' + 'install'.magenta + ' command downloads pre-built node apps');
     jitsu.log.info('Please select a node app to get started');
     jitsu.log.info('Available node apps:');
+
     Object.keys(nodeapps).forEach(function (starter) {
       jitsu.log.info(starter.magenta + ' ' + nodeapps[starter].description);
     });
@@ -159,7 +153,6 @@ module.exports = function (requestedApp, callback) {
   }
 
   function postInstall(appName, cb) {
-
     app.name = appName;
 
     jitsu.log.info(app.name.magenta + ' installed');
@@ -184,8 +177,7 @@ module.exports = function (requestedApp, callback) {
   }
 
   function configureApp (schema, cb) {
-
-    jitsu.log.info('Attempting to configure app based on ' + './config/schema.json'.grey )
+    jitsu.log.info('Attempting to configure app based on ' + './config/schema.json'.grey);
     jitsu.log.help('Prompting for ' + app.name.magenta + ' configuration data');
     jitsu.log.help('Press ' + '[ENTER]'.grey + ' to specify default values');
 
@@ -229,7 +221,7 @@ module.exports = function (requestedApp, callback) {
         jitsu.log.warn('Cancelled');
         return cb(null, 'Cancelled');
       }
-      return results['start_local'] === 'yes'
+      return results.start_local === 'yes'
         ? startApp('local', cb)
         : cb(null);
     });
@@ -252,7 +244,7 @@ module.exports = function (requestedApp, callback) {
       if (err) {
         return cb(err);
       }
-      
+
       jitsu.log.info('The app has been created successfully. Deploying!');
       jitsu.log.info('Run additional deployments using `jitsu deploy`');
       return jitsu.plugins.cli.executeCommand(['deploy'],callback);


### PR DESCRIPTION
Added support for the ghost blog platform as example application and added support for a custom `jitsu-install` hook that will be ran once we've installed the demo application. This allows us to further configure applications when needed. (like creating databases etc)
