### PR TITLE
logs: output real JSON when --raw is specified

### DIFF
--- a/lib/jitsu/commands/logs.js
+++ b/lib/jitsu/commands/logs.js
@@ -241,7 +241,7 @@ function printLog(datum) {
   if (datum.description && datum.description !== null) {
 
     if (jitsu.argv.raw) {
-      return console.log(datum);
+      return console.log(JSON.stringify(datum));
     }
 
     datum.description.split('\n').forEach(function (line) {


### PR DESCRIPTION
makes the "raw" output actually parseable
