### PR TITLE
[minor] ProgressBar style lint.

### DIFF
--- a/lib/jitsu/package.js
+++ b/lib/jitsu/package.js
@@ -438,7 +438,7 @@ package.updateTarball = function (version, pkg, existing, firstSnapshot, callbac
           var size;
           emitter.on('start', function (stats) {
             size = stats.size;
-            bar = new ProgressBar('info'.green + '\t Uploading: [:bar] :percent',{
+            bar = new ProgressBar('info'.green + ':\t Uploading: [:bar] :percent',{
               complete  : '=',
               incomplete: ' ',
               width     : 30 ,


### PR DESCRIPTION
Added the missing semicolon that is found on every other jitsu output line.
